### PR TITLE
修改TextInputLayout的类型

### DIFF
--- a/ans-demo/visualDemo/src/main/res/layout/activity_login_activity.xml
+++ b/ans-demo/visualDemo/src/main/res/layout/activity_login_activity.xml
@@ -31,7 +31,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
@@ -44,9 +44,9 @@
                     android:maxLines="1"
                     android:singleLine="true" />
 
-            </android.support.design.widget.TextInputLayout>
+            </com.google.android.material.textfield.TextInputLayout>
 
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
@@ -62,7 +62,7 @@
                     android:maxLines="1"
                     android:singleLine="true" />
 
-            </android.support.design.widget.TextInputLayout>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <Button
                 android:id="@+id/email_sign_in_button"

--- a/ans-demo/visualDemo/src/main/res/layout/activity_visual_relative.xml
+++ b/ans-demo/visualDemo/src/main/res/layout/activity_visual_relative.xml
@@ -44,7 +44,7 @@
 
                 android:onClick="onClick">
 
-                <android.support.constraint.ConstraintLayout
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/cccRelativeLayout"
                     android:layout_width="100dp"
                     android:layout_height="120dp"
@@ -59,7 +59,7 @@
                         android:onClick="onClick"
                         android:text="多层嵌套" />
 
-                </android.support.constraint.ConstraintLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
             </AbsoluteLayout>
         </LinearLayout>
 

--- a/ans-demo/visualDemo/src/main/res/layout/activity_visual_view_pager.xml
+++ b/ans-demo/visualDemo/src/main/res/layout/activity_visual_view_pager.xml
@@ -48,7 +48,7 @@
         android:scaleType="matrix"
         android:src="@drawable/background_visual" />
 
-    <android.support.v4.view.ViewPager
+    <androidx.viewpager.widget.ViewPager
         android:id="@+id/vPager"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
android.support.design.widget.TextInputLayout导致闪退，故修改成com.google.android.material.textfield.TextInputLayout